### PR TITLE
Use luerl fork to replace original luerl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ PROJECT_VERSION = 2.2
 
 DEPS = lager luerl
 dep_lager    = git https://github.com/basho/lager
-dep_luerl    = git https://github.com/rvirding/luerl
+dep_luerl    = git https://github.com/grutabow/luerl
 
 BUILD_DEPS = emqttd cuttlefish
-dep_emqttd = git https://github.com/emqtt/emqttd develop
+dep_emqttd     = git https://github.com/emqtt/emqttd develop
 dep_cuttlefish = git https://github.com/emqtt/cuttlefish
 
 ERLC_OPTS += +'{parse_transform, lager_transform}'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dep_lager    = git https://github.com/basho/lager
 dep_luerl    = git https://github.com/grutabow/luerl
 
 BUILD_DEPS = emqttd cuttlefish
-dep_emqttd     = git https://github.com/emqtt/emqttd develop
+dep_emqttd     = git https://github.com/emqtt/emqttd
 dep_cuttlefish = git https://github.com/emqtt/cuttlefish
 
 ERLC_OPTS += +'{parse_transform, lager_transform}'

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ This API exports hook(s) implemented in its lua script.
 # example code
 
 ```lua
-function on_message_publish(topic, payload, qos, retain)
+function on_message_publish(clientid, username, topic, payload, qos, retain)
     return topic, "hello", qos, retain
 end
 

--- a/src/emq_lua_hook_cli.erl
+++ b/src/emq_lua_hook_cli.erl
@@ -174,10 +174,13 @@ do_loadall() ->
 
 do_load(FileName) ->
     case catch luerl:dofile(FileName) of
+        {'EXIT', St00} ->
+            ?LOG(error, "Failed to load lua script ~p due to error ~p", [FileName, St00]),
+            error;
         {_Ret, St0} ->
             case catch luerl:call_function([register_hook], [], St0) of
-                {'EXIT', _St1} ->
-                    ?LOG(error, "Failed to load lua script ~p, which has syntax error", [FileName]),
+                {'EXIT', St1} ->
+                    ?LOG(error, "Failed to execute register_hook function in lua script ~p, which has syntax error, St1=~p", [FileName, St1]),
                     error;
                 {Ret1, St1} ->
                     ?LOG(debug, "Register lua script ~p", [FileName]),


### PR DESCRIPTION
Original luerl has a bug which always raise {error, tokens} while loading lua scripts, even the script is empty.